### PR TITLE
Swapping LMGTFY link for GitHub instructions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You need to have git installed locally so you can clone your fork of the ng-inte
 ### Fork and Clone rails-interview
 
 Fork the [rails-interview][rails-interview] repository on GitHub.
-If you are unfamiliar with forking, [follow these instructions](http://lmgtfy.com/?q=how+to+fork+a+repo+in+github).
+If you are unfamiliar with forking, [follow these instructions](https://help.github.com/articles/fork-a-repo) provided by GitHub.
 
 Then clone your repository locally using [git][git]:
 


### PR DESCRIPTION
The Imagine Math team culture focuses on kindness and helpfulness.
Having a LMGTFY link in our instructions sends the wrong message
to the Globant team and comes off as unprofessional.  The link
has been updated with the GitHub help link to properly reflect
our current style of documentation and tone.